### PR TITLE
Rename podspec to swift-user-defaults, add makefile and update readme 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PODSPEC = swift-user-defaults.podspec
+
+setup:
+	bundle install
+
+lint:	setup
+	bundle exec pod lib lint --allow-warnings
+
+release: lint
+	bundle exec pod trunk push $(PODSPEC)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PODSPEC = swift-user-defaults.podspec
-
 setup:
 	bundle install
 
@@ -7,4 +5,4 @@ lint:	setup
 	bundle exec pod lib lint --allow-warnings
 
 release: lint
-	bundle exec pod trunk push $(PODSPEC)
+	bundle exec pod trunk push

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ As with the `UserDefault.X` APIs, the property wrapper supports primitive, `RawR
 
 # Installation
 
+## CocoaPods
+
+[CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate SwiftUserDefaults into your Xcode project using CocoaPods, specify it in your `Podfile`:
+
+```ruby
+pod 'swift-user-defaults'
+```
+
 ## Swift Package Manager
 
 Add the following to your **Package.swift**

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name = "SwiftUserDefaults"
+  s.name = "swift-user-defaults"
   s.version = "0.0.1"
   s.summary = "A series of Swift friendly utilities for Foundation's UserDefaults class"
   s.homepage = "https://github.com/cookpad/swift-user-defaults"

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "swift-user-defaults"
+  s.module_name = "SwiftUserDefaults"
   s.version = "0.0.2"
   s.summary = "A series of Swift friendly utilities for Foundation's UserDefaults class"
   s.homepage = "https://github.com/cookpad/swift-user-defaults"

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "swift-user-defaults"
-  s.version = "0.0.1"
+  s.version = "0.0.2"
   s.summary = "A series of Swift friendly utilities for Foundation's UserDefaults class"
   s.homepage = "https://github.com/cookpad/swift-user-defaults"
   s.license = { :type => "MIT", :file => "LICENSE.txt" }


### PR DESCRIPTION
# Background 

- https://github.com/cookpad/swift-user-defaults/issues/2

# Overview 

A CocoaPod named `SwiftUserDefaults` already exists. As such we need to rename to something available i.e `swift-user-defaults`. The module name however, will remain `SwiftUserDefaults`.

As pod support get closer to release, we need to create convenient ways to manage the release, and better document Cocoapod support in the repository.

# Tasks 

- Rename podspec file and spec property name from `SwiftUserDefaults` to `swift-user-defaults`
- Update the version of the pod to `v0.0.2` 
- Add the `module_name` property `SwiftUserDefaults` to the spec 
- Add `Makefile` for targets `setup`, `lint`, `release` which have prerequisites of each other respectively
- Update `README.md` with CocoaPods installation instructions