### PR TITLE
Run library and example project tests against multiple Xcode versions and device destinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ jobs:
   build:
 
     runs-on: macos-11
+    env:
+      SCHEME: "swift-user-defaults"
+      EXAMPLE_SCHEME: "Example"
+      WORKSPACE: "Example/Example.xcworkspace"
+      DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer'
+
+    strategy:
+      matrix:
+        xcode_version: ['12.5', '13.1']
+        include:
+        - xcode_version: '12.5'
+          destination_ios: 'OS=14.5,name=iPhone 12'
+          destination_macos: 'platform=macOS'
+        - xcode_version: '13.1'
+          destination_ios: 'OS=15.0,name=iPhone 13'
+          destination_macos: 'platform=macOS'
 
     steps:
     - uses: actions/checkout@v2
@@ -20,13 +36,19 @@ jobs:
       with:
         bundler-cache: true
 
-    # Build
-    - name: Build
+    # Build library & Run Unit-Tests (MacOS)
+    - name: Build library MacOS
       run: swift build -v
-
-    # Run Unit Tests
-    - name: Run tests
+    - name: Run library unit-tests MacOS
       run: swift test -v
+
+    # Build library & Run Unit-Tests (iOS)
+    - name: Build & Unit-tests for Library iOS
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
+
+    # Build Example Project & Run UI-Tests (iOS)
+    - name: Build & UI-Test Example Project for iOS
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace $WORKSPACE -scheme $EXAMPLE_SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
 
     # Verify CocoaPods
     - name: Verify CocoaPods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,15 @@ jobs:
         bundler-cache: true
 
     # Build library & Run Unit-Tests (MacOS)
-    - name: Build library MacOS
-      run: swift build -v
-    - name: Run library unit-tests MacOS
-      run: swift test -v
+    - name: Build & Unit-Test Library (MacOS)
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_macos }}" clean test | bundle exec xcpretty
 
     # Build library & Run Unit-Tests (iOS)
-    - name: Build & Unit-tests for Library iOS
+    - name: Build & Unit-Test Library (iOS)
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
 
     # Build Example Project & Run UI-Tests (iOS)
-    - name: Build & UI-Test Example Project for iOS
+    - name: Build & UI-Test Example Project (iOS)
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace $WORKSPACE -scheme $EXAMPLE_SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
 
     # Verify CocoaPods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: macos-11
     env:
       SCHEME: "swift-user-defaults"
-      EXAMPLE_SCHEME: "Example"
-      WORKSPACE: "Example/Example.xcworkspace"
       DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer'
 
     strategy:
@@ -46,7 +44,7 @@ jobs:
 
     # Build Example Project & Run UI-Tests (iOS)
     - name: Build & UI-Test Example Project (iOS)
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace $WORKSPACE -scheme $EXAMPLE_SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "Example/Example.xcworkspace" -scheme "Example" -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
 
     # Verify CocoaPods
     - name: Verify CocoaPods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    name: Checks (Xcode ${{ matrix.xcode_version }})
     runs-on: macos-11
     env:
       SCHEME: "swift-user-defaults"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 # Cocoapods for iOS dependency management
 gem 'cocoapods'
+
+# XCPretty gem for ci workflow output formatting
+gem 'xcpretty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     netrc (0.11.0)
     public_suffix (4.0.6)
     rexml (3.2.5)
+    rouge (2.0.7)
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
@@ -85,6 +86,8 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
+    xcpretty (0.3.0)
+      rouge (~> 2.0.7)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -93,6 +96,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
+  xcpretty
 
 BUNDLED WITH
    2.2.22


### PR DESCRIPTION
# Background 

- raise issue

# Overview 

Improve test coverage of swift library and example project by using multiple Xcode versions and device OS (iOS).
Sets the foundation for watchOS and tvOS destinations.

# Tasks 

- Add `xcpretty` to Gem file (used for formatting of output in workflow jobs)
- Add matrix to `ci.yml` workflow to support Xcode 12 and 13 devices
- Build & Run library Unit-Tests on MacOS
- Build & Run library Unit-Tests on iOS 
- Build & Run Example UI-Tests on iOS 