### PR TITLE
Add support for watchOS and tvOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,13 @@ jobs:
         - xcode_version: '12.5'
           destination_ios: 'OS=14.5,name=iPhone 12'
           destination_macos: 'platform=macOS'
+          destination_watchos: 'OS=7.4,name=Apple Watch Series 6 - 44mm'
+          destination_tvos: 'OS=14.5,name=Apple TV'
         - xcode_version: '13.1'
           destination_ios: 'OS=15.0,name=iPhone 13'
           destination_macos: 'platform=macOS'
+          destination_watchos: 'OS=8.0,name=Apple Watch Series 7 - 45mm'
+          destination_tvos: 'OS=15.0,name=Apple TV'
 
     steps:
     - uses: actions/checkout@v2
@@ -41,6 +45,14 @@ jobs:
     # Build library & Run Unit-Tests (iOS)
     - name: Build & Unit-Test Library (iOS)
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_ios }}" clean test | bundle exec xcpretty
+
+    # Build library & Run Unit-Tests (watchOS)
+    - name: Build & Unit-Test Library (watchOS)
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_watchos }}" clean test | bundle exec xcpretty
+
+    # Build library & Run Unit-Tests (tvOS)
+    - name: Build & Unit-Test Library (tvOS)
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme $SCHEME -destination "${{ matrix.destination_tvos }}" clean test | bundle exec xcpretty
 
     # Build Example Project & Run UI-Tests (iOS)
     - name: Build & UI-Test Example Project (iOS)

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ let package = Package(
     name: "swift-user-defaults",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v11)
+        .iOS(.v11),
+        .watchOS(.v7),
+        .tvOS(.v10)
     ],
     products: [
         .library(name: "SwiftUserDefaults", targets: ["SwiftUserDefaults"]),

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '7'
 
   # Run Unit Tests
   s.test_spec 'Tests' do |test_spec|


### PR DESCRIPTION
# Background 

- https://github.com/cookpad/swift-user-defaults/issues/2

# Overview 

Improve SwiftUserDefaults library test coverage via both package and pods on the CI.

# Tasks 

- Test library against tvOS
- Test library against watchOS