### PR TITLE
Introduce new `@UserDefaultOverride` property wrapper for better UI testing support

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -26,6 +26,7 @@ import SwiftUI
 struct ContentView: View {
     // AppStorage is backed by UserDefaults so this works too!
     @AppStorage(.contentTitle) var title: String?
+    @AppStorage(.contentSortOrder) var sortOrder: ContentSortOrder = .descending
     @ObservedObject var viewModel = ContentViewModel()
 
     var body: some View {
@@ -37,7 +38,7 @@ struct ContentView: View {
                         .frame(maxWidth: .infinity)
                 } else {
                     List {
-                        ForEach(viewModel.items, id: \.self) { item in
+                        ForEach(viewModel.items.sorted(by: sortOrder.compare(lhs:rhs:)), id: \.self) { item in
                             Text("\(item, formatter: viewModel.dateFormatter)")
                         }
                         .onDelete(perform: { viewModel.items.remove(atOffsets: $0) })

--- a/Example/ExampleKit/Sources/ExampleKit/ExamplePreferences.swift
+++ b/Example/ExampleKit/Sources/ExampleKit/ExamplePreferences.swift
@@ -31,4 +31,20 @@ public extension UserDefaults.Key {
 
     /// User defaults key representing the items displayed in the list of `ContentView`
     static let contentItems = Self("ContentItems")
+
+    /// The order used to sort the items that are displayed in `ContentView`
+    static let contentSortOrder = Self("ContentSortOrder")
+}
+
+public enum ContentSortOrder: String {
+    case ascending, descending
+
+    public func compare<T: Comparable>(lhs: T, rhs: T) -> Bool {
+        switch self {
+        case .ascending:
+            return lhs < rhs
+        case .descending:
+            return lhs > rhs
+        }
+    }
 }

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -38,7 +38,7 @@ class ExampleUITests: XCTestCase {
         var deviceLocale: Locale = Locale(identifier: "en_US")
 
         var additionalLaunchArguments: [String] {
-            // Type `Locale` doesn't match how we want to represen the `AppleLocale` UserDefault so we'll encode it manually
+            // Type `Locale` doesn't match how we want to represent the `AppleLocale` UserDefault so we'll encode it manually
             var container = UserDefaults.ValueContainer()
             container.set(deviceLocale.identifier, forKey: UserDefaults.Key("AppleLocale"))
 

--- a/README.md
+++ b/README.md
@@ -198,15 +198,25 @@ import MyAppCommon
 import SwiftUserDefaults
 import XCTest
 
+struct MyAppConfiguration: LaunchArgumentEncodable {
+    @UserDefaultOverride(key: .currentLevel)
+    var currentLevel: Int?
+    
+    @UserDefaultOverride(key: .userName)
+    var userName: String?
+    
+    @UserDefaultOverride(key: .userGUID)
+    var userGUID = "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+}
+
 final class MyAppTests: XCTestCase {
-    func testMyApp() {
-        var container = UserDefaults.ValueContainer()
-        container.set(8, forKey: .currentLevel)
-        container.set("John Doe", forKey: .userName)
-        container.set("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", forKey: .userGUID)
+    func testMyApp() throws {
+        var configuration = MyAppConfiguration()
+        container.currentLevel = 8
+        container.userName = "John Doe"
 
         let app = XCUIApplication()
-        app.launchArguments = container.launchArguments
+        app.launchArguments = try configuration.encodeLaunchArguments()
         app.launch()
 
         // ...

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ import SwiftUserDefaults
 import XCTest
 
 struct MyAppConfiguration: LaunchArgumentEncodable {
-    @UserDefaultOverride(key: .currentLevel)
+    @UserDefaultOverride(.currentLevel)
     var currentLevel: Int?
     
-    @UserDefaultOverride(key: .userName)
+    @UserDefaultOverride(.userName)
     var userName: String?
     
-    @UserDefaultOverride(key: .userGUID)
+    @UserDefaultOverride(.userGUID)
     var userGUID = "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
 }
 

--- a/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
+++ b/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
@@ -25,8 +25,8 @@ public extension LaunchArgumentEncodable {
         var container = UserDefaults.ValueContainer()
 
         for child in mirror.children {
-            if let argument = child.value as? UserDefaultKeyValueRepresentable, let (key, value) = try argument.keyValuePair() {
-                container.set(value, forKey: key)
+            if let override = child.value as? UserDefaultOverrideRepresentable, let value = try override.getValue() {
+                container.set(value, forKey: override.key)
             }
         }
 

--- a/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
+++ b/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// A protocol used by container types that can have their representations encoded into launch arguments via the ``encodeLaunchArguments()`` method.
+///
+/// This protocol works exclusively in conjunction with the ``UserDefaultOverride`` property wrapper.
+public protocol LaunchArgumentEncodable {
+    /// Additional values to be apended to the result of `collectLaunchArguments()`.
+    ///
+    /// A default implementation is provided that returns an empty array.
+    var additionalLaunchArguments: [String] { get }
+}
+
+public extension LaunchArgumentEncodable {
+    var additionalLaunchArguments: [String] {
+        []
+    }
+
+    /// Collects the complete array of launch arguments from the reciever.
+    ///
+    /// The contents of the return value is built by using Reflection to look for all `@UserDefaultOverride` property wrapper instances. See ``UserDefaultOverride`` for more information.
+    ///
+    /// In addition to overrides, the contents of `additionalLaunchArguments` is apended to the return value.
+    func encodeLaunchArguments() throws -> [String] {
+        let mirror = Mirror(reflecting: self)
+        var container = UserDefaults.ValueContainer()
+
+        for child in mirror.children {
+            if let argument = child.value as? UserDefaultKeyValueRepresentable, let (key, value) = try argument.keyValuePair() {
+                container.set(value, forKey: key)
+            }
+        }
+
+        return container.launchArguments + additionalLaunchArguments
+    }
+}

--- a/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
+++ b/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// This protocol works exclusively in conjunction with the ``UserDefaultOverride`` property wrapper.
 public protocol LaunchArgumentEncodable {
-    /// Additional values to be apended to the result of `collectLaunchArguments()`.
+    /// Additional values to be appended to the result of `collectLaunchArguments()`.
     ///
     /// A default implementation is provided that returns an empty array.
     var additionalLaunchArguments: [String] { get }
@@ -15,11 +15,11 @@ public extension LaunchArgumentEncodable {
         []
     }
 
-    /// Collects the complete array of launch arguments from the reciever.
+    /// Collects the complete array of launch arguments from the receiver.
     ///
     /// The contents of the return value is built by using Reflection to look for all `@UserDefaultOverride` property wrapper instances. See ``UserDefaultOverride`` for more information.
     ///
-    /// In addition to overrides, the contents of `additionalLaunchArguments` is apended to the return value.
+    /// In addition to overrides, the contents of `additionalLaunchArguments` is appended to the return value.
     func encodeLaunchArguments() throws -> [String] {
         let mirror = Mirror(reflecting: self)
         var container = UserDefaults.ValueContainer()

--- a/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
+++ b/Sources/SwiftUserDefaults/LaunchArgumentEncodable.swift
@@ -8,11 +8,24 @@ public protocol LaunchArgumentEncodable {
     ///
     /// A default implementation is provided that returns an empty array.
     var additionalLaunchArguments: [String] { get }
+
+    /// An array of types that represent UserDefault key/value overrides to be converted into launch arguments.
+    ///
+    /// A default implementation is provided that uses reflection to collect these values from the receiver.
+    /// You are free to override and provide your own implementation if you would prefer.
+    var userDefaultOverrides: [UserDefaultOverrideRepresentable] { get }
 }
 
 public extension LaunchArgumentEncodable {
     var additionalLaunchArguments: [String] {
         []
+    }
+
+    /// Uses reflection to collect properties that conform to `UserDefaultOverrideRepresentable` from the receiver.
+    var userDefaultOverrides: [UserDefaultOverrideRepresentable] {
+        Mirror(reflecting: self)
+            .children
+            .compactMap { $0.value as? UserDefaultOverrideRepresentable }
     }
 
     /// Collects the complete array of launch arguments from the receiver.
@@ -21,15 +34,15 @@ public extension LaunchArgumentEncodable {
     ///
     /// In addition to overrides, the contents of `additionalLaunchArguments` is appended to the return value.
     func encodeLaunchArguments() throws -> [String] {
-        let mirror = Mirror(reflecting: self)
+        // Map the overrides into a container
         var container = UserDefaults.ValueContainer()
-
-        for child in mirror.children {
-            if let override = child.value as? UserDefaultOverrideRepresentable, let value = try override.getValue() {
-                container.set(value, forKey: override.key)
-            }
+        for userDefaultOverride in userDefaultOverrides {
+            // Add the storable value into the container only if it wasn't nil
+            guard let value = try userDefaultOverride.getValue() else { continue }
+            container.set(value, forKey: userDefaultOverride.key)
         }
 
+        // Return the collected user default overrides along with any additional arguments
         return container.launchArguments + additionalLaunchArguments
     }
 }

--- a/Sources/SwiftUserDefaults/UserDefaultOverride.swift
+++ b/Sources/SwiftUserDefaults/UserDefaultOverride.swift
@@ -40,15 +40,15 @@ import Foundation
 ///
 /// struct AppConfiguration: LaunchArgumentEncodable {
 ///     // An optional Codable property, encoded to data using the `.plist` strategy.
-///     @UserDefaultOverride(key: .user, strategy: .plist)
+///     @UserDefaultOverride(.user, strategy: .plist)
 ///     var user: User?
 ///
 ///     // A RawRepresentable enum with a default value, encoded to it's backing `rawValue` (a String).
-///     @UserDefaultOverride(key: .state)
+///     @UserDefaultOverride(.state)
 ///     var state: State = .unregistered
 ///
 ///     // An optional primative type (Bool). When `nil`, values will not be used as an override since null cannot be represented.
-///     @UserDefaultOverride(key: .isLegacyUser)
+///     @UserDefaultOverride(.isLegacyUser)
 ///     var isLegacyUser: Bool?
 ///
 ///     // A convenient place to define other launch arguments that don't relate to `UserDefaults`.
@@ -117,40 +117,40 @@ public struct UserDefaultOverride<Value> {
 
     public init(
         wrappedValue defaultValue: Value,
-        key: UserDefaults.Key
+        _ key: UserDefaults.Key
     ) where Value: UserDefaultsStorable {
         self.init(wrappedValue: defaultValue, key: key, transform: { $0 })
     }
 
     public init<T: UserDefaultsStorable>(
-        key: UserDefaults.Key
+        _ key: UserDefaults.Key
     ) where Value == T? {
         self.init(wrappedValue: nil, key: key, transform: { $0 })
     }
 
     public init(
         wrappedValue defaultValue: Value,
-        key: UserDefaults.Key
+        _ key: UserDefaults.Key
     ) where Value: RawRepresentable, Value.RawValue: UserDefaultsStorable {
         self.init(wrappedValue: defaultValue, key: key, transform: { $0.rawValue })
     }
 
     public init<T: RawRepresentable>(
-        key: UserDefaults.Key
+        _ key: UserDefaults.Key
     ) where Value == T?, T.RawValue: UserDefaultsStorable {
         self.init(wrappedValue: nil, key: key, transform: { $0?.rawValue })
     }
 
     public init(
         wrappedValue defaultValue: Value,
-        key: UserDefaults.Key,
+        _ key: UserDefaults.Key,
         strategy: UserDefaults.CodingStrategy
     ) where Value: Encodable {
         self.init(wrappedValue: defaultValue, key: key, transform: { try strategy.encode($0) })
     }
 
     public init<T: Encodable>(
-        key: UserDefaults.Key,
+        _ key: UserDefaults.Key,
         strategy: UserDefaults.CodingStrategy
     ) where Value == T? {
         self.init(wrappedValue: nil, key: key, transform: { try $0.flatMap({ try strategy.encode($0) }) })

--- a/Sources/SwiftUserDefaults/UserDefaultOverride.swift
+++ b/Sources/SwiftUserDefaults/UserDefaultOverride.swift
@@ -47,7 +47,7 @@ import Foundation
 ///     @UserDefaultOverride(.state)
 ///     var state: State = .unregistered
 ///
-///     // An optional primative type (Bool). When `nil`, values will not be used as an override since null cannot be represented.
+///     // An optional primitive type (Bool). When `nil`, values will not be used as an override since null cannot be represented.
 ///     @UserDefaultOverride(.isLegacyUser)
 ///     var isLegacyUser: Bool?
 ///
@@ -58,7 +58,7 @@ import Foundation
 /// }
 /// ```
 ///
-/// Finally, in your test cases, create and configure an instnace of your container type and use the `collectLaunchArguments()` method to pass the overrides into your `XCUIApplication` and perform the UI tests like normal. The overrides will be picked up by `UserDefaults` instances in your app to help you in testing preconfigured states.
+/// Finally, in your test cases, create and configure an instance of your container type and use the `collectLaunchArguments()` method to pass the overrides into your `XCUIApplication` and perform the UI tests like normal. The overrides will be picked up by `UserDefaults` instances in your app to help you in testing pre-configured states.
 ///
 /// ```swift
 /// import SwiftUserDefaults
@@ -76,7 +76,7 @@ import Foundation
 ///         app.launchArguments = try configuration.encodeLaunchArguments()
 ///         app.launch()
 ///
-///         // The launch arugments will look like the following:
+///         // The launch arguments will look like the following:
 ///         app.launchArguments
 ///         // ["-User", "<data>...</data>", "-State", "<string>registered</string>", "UI-Testing"]
 ///

--- a/Sources/SwiftUserDefaults/UserDefaultOverride.swift
+++ b/Sources/SwiftUserDefaults/UserDefaultOverride.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+/// A property wrapper used for marking types as a value that should be used as an override in `UserDefaults`.
+///
+/// On its own, `@UserDefaultOverride` or `LaunchOverrides` cannot override values stored in `UserDefaults`, but they can provide an array of launch arguments that you can then pass to a process. There are two scenarios where you might find this useful:
+///
+/// 1. Running UI Tests via XCTest, you might set `XCUIApplication`'s `launchArguments` array before calling `launch()`.
+/// 2. Invoking a `Process`, you might pass values to the `arguments` array.
+///
+/// **UI Test Example**
+///
+/// When using SwiftUserDefaults, if you define `UserDefaults.Key` definitions and other model types in a separate framework target (in this example, `MyFramework`), you can then share them between your application target and your UI test target:
+///
+/// ```swift
+/// import SwiftUserDefaults
+///
+/// public extension UserDefaults.Key {
+///     public static let user = Self("User")
+///     public static let state = Self("State")
+///     public static let isLegacyUser = Self("LegacyUser")
+/// }
+///
+/// public struct User: Codable {
+///     public var name: String
+///
+///     public init(name: String) {
+///         self.name = name
+///     }
+/// }
+///
+/// public enum State: String {
+///     case registered, unregistered
+/// }
+/// ```
+/// To easily manage overrides in your UI Testing target, import your framework target and define a container that conforms to `LaunchArgumentEncodable`. In this container, use the `@UserDefaultOverride` property wrapper to build up a configuration of overrides that match usage in your app:
+///
+/// ```swift
+/// import MyFramework
+/// import SwiftUserDefaults
+///
+/// struct AppConfiguration: LaunchArgumentEncodable {
+///     // An optional Codable property, encoded to data using the `.plist` strategy.
+///     @UserDefaultOverride(key: .user, strategy: .plist)
+///     var user: User?
+///
+///     // A RawRepresentable enum with a default value, encoded to it's backing `rawValue` (a String).
+///     @UserDefaultOverride(key: .state)
+///     var state: State = .unregistered
+///
+///     // An optional primative type (Bool). When `nil`, values will not be used as an override since null cannot be represented.
+///     @UserDefaultOverride(key: .isLegacyUser)
+///     var isLegacyUser: Bool?
+///
+///     // A convenient place to define other launch arguments that don't relate to `UserDefaults`.
+///     var additionalLaunchArguments: [String] {
+///         ["UI-Testing"]
+///     }
+/// }
+/// ```
+///
+/// Finally, in your test cases, create and configure an instnace of your container type and use the `collectLaunchArguments()` method to pass the overrides into your `XCUIApplication` and perform the UI tests like normal. The overrides will be picked up by `UserDefaults` instances in your app to help you in testing preconfigured states.
+///
+/// ```swift
+/// import SwiftUserDefaults
+/// import XCTest
+///
+/// class MyAppUITestCase: XCTestCase {
+///     func testScenario() throws {
+///         // Create a configuration, update the overrides
+///         var configuration = AppConfiguration()
+///         configuration.user = User(name: "John")
+///         configuration.state = .registered
+///
+///         // Create the test app, assign the launch arguments and launch the process.
+///         let app = XCUIApplication()
+///         app.launchArguments = try configuration.encodeLaunchArguments()
+///         app.launch()
+///
+///         // The launch arugments will look like the following:
+///         app.launchArguments
+///         // ["-User", "<data>...</data>", "-State", "<string>registered</string>", "UI-Testing"]
+///
+///         // ...
+///     }
+/// }
+/// ```
+@propertyWrapper
+public struct UserDefaultOverride<Value> {
+    let getValue: () -> Value
+    let setValue: (Value) -> Void
+    let getKeyValuePair: () throws -> (key: UserDefaults.Key, value: UserDefaultsStorable)?
+
+    public var wrappedValue: Value {
+        get {
+            getValue()
+        }
+        set {
+            setValue(newValue)
+        }
+    }
+
+    init(
+        wrappedValue defaultValue: Value,
+        key: UserDefaults.Key,
+        transform: @escaping (Value) throws -> UserDefaultsStorable?
+    ) {
+        var value: Value = defaultValue
+
+        getValue = { value }
+        setValue = { value = $0 }
+
+        getKeyValuePair = {
+            guard let value = try transform(value) else { return nil }
+            return (key: key, value: value)
+        }
+    }
+
+    public init(
+        wrappedValue defaultValue: Value,
+        key: UserDefaults.Key
+    ) where Value: UserDefaultsStorable {
+        self.init(wrappedValue: defaultValue, key: key, transform: { $0 })
+    }
+
+    public init<T: UserDefaultsStorable>(
+        key: UserDefaults.Key
+    ) where Value == T? {
+        self.init(wrappedValue: nil, key: key, transform: { $0 })
+    }
+
+    public init(
+        wrappedValue defaultValue: Value,
+        key: UserDefaults.Key
+    ) where Value: RawRepresentable, Value.RawValue: UserDefaultsStorable {
+        self.init(wrappedValue: defaultValue, key: key, transform: { $0.rawValue })
+    }
+
+    public init<T: RawRepresentable>(
+        key: UserDefaults.Key
+    ) where Value == T?, T.RawValue: UserDefaultsStorable {
+        self.init(wrappedValue: nil, key: key, transform: { $0?.rawValue })
+    }
+
+    public init(
+        wrappedValue defaultValue: Value,
+        key: UserDefaults.Key,
+        strategy: UserDefaults.CodingStrategy
+    ) where Value: Encodable {
+        self.init(wrappedValue: defaultValue, key: key, transform: { try strategy.encode($0) })
+    }
+
+    public init<T: Encodable>(
+        key: UserDefaults.Key,
+        strategy: UserDefaults.CodingStrategy
+    ) where Value == T? {
+        self.init(wrappedValue: nil, key: key, transform: { try $0.flatMap({ try strategy.encode($0) }) })
+    }
+}
+
+// MARK: - UserDefaultKeyValueRepresentable
+
+/// Internal protocol to help erase generic type information from `UserDefaultOverride` when attempting to obtain the key value pair.
+protocol UserDefaultKeyValueRepresentable {
+    /// Returns the pair, nil or an error upon request.
+    func keyValuePair() throws -> (key: UserDefaults.Key, value: UserDefaultsStorable)?
+}
+
+extension UserDefaultOverride: UserDefaultKeyValueRepresentable {
+    func keyValuePair() throws -> (key: UserDefaults.Key, value: UserDefaultsStorable)? {
+        try getKeyValuePair()
+    }
+}

--- a/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
+++ b/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
@@ -32,31 +32,31 @@ private struct AppConfiguration: LaunchArgumentEncodable {
     }
 
     // UserDefaultsStorable with default value
-    @UserDefaultOverride(key: .uuid)
+    @UserDefaultOverride(.uuid)
     var uuid: String = "TESTING"
 
     // Optional Codable
-    @UserDefaultOverride(key: .user, strategy: .json)
+    @UserDefaultOverride(.user, strategy: .json)
     var user: User?
 
     // RawRepresentable with default value
-    @UserDefaultOverride(key: .state)
+    @UserDefaultOverride(.state)
     var state: State = .unregistered
 
     // Optional RawRepresentable
-    @UserDefaultOverride(key: .lastState)
+    @UserDefaultOverride(.lastState)
     var lastState: State?
 
     // Optional UserDefaultsStorable
-    @UserDefaultOverride(key: .isLegacyUser)
+    @UserDefaultOverride(.isLegacyUser)
     var isLegacyUser: Bool?
 
     // Optional UserDefaultsStorable
-    @UserDefaultOverride(key: .lastVisitDate)
+    @UserDefaultOverride(.lastVisitDate)
     var lastVisitDate: Date?
 
     // Codable with default value
-    @UserDefaultOverride(key: .windowPreferences, strategy: .json)
+    @UserDefaultOverride(.windowPreferences, strategy: .json)
     var windowPreferences: [WindowPreference] = []
 
     // The device locale to mock, can't be represented as a single @UserDefaultOverride

--- a/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
+++ b/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
@@ -25,10 +25,9 @@ private struct AppConfiguration: LaunchArgumentEncodable {
         case registered, unregistered
     }
 
-    enum WindowPreference: Codable, Equatable {
-        case fullScreen
-        case fixed(width: Float)
-        case disableMinimize
+    struct WindowPreferences: Codable, Equatable {
+        var isFullScreenSupported: Bool = false
+        var isMinimizeEnabled: Bool = true
     }
 
     // UserDefaultsStorable with default value
@@ -57,21 +56,14 @@ private struct AppConfiguration: LaunchArgumentEncodable {
 
     // Codable with default value
     @UserDefaultOverride(.windowPreferences, strategy: .json)
-    var windowPreferences: [WindowPreference] = []
+    var windowPreferences: WindowPreferences = WindowPreferences()
 
     // The device locale to mock, can't be represented as a single @UserDefaultOverride
     var deviceLocale: Locale = Locale(identifier: "en_US")
 
     // Additonal Launch Arguments
     var additionalLaunchArguments: [String] {
-        // TODO: Remove this from the tests and place it in the Example project.
-        var container = UserDefaults.ValueContainer()
-        container.set([deviceLocale.languageCode!], forKey: .appleLanguages)
-        container.set(deviceLocale.identifier, forKey: .appleLocale)
-
-        return container.launchArguments + [
-            "UI-Testing"
-        ]
+        ["UI-Testing"]
     }
 }
 
@@ -82,7 +74,7 @@ class LaunchArgumentEncodableTests: XCTestCase {
         configuration.state = .registered
         configuration.lastState = .unregistered
         configuration.lastVisitDate = Date(timeIntervalSinceReferenceDate: 60 * 60 * 24)
-        configuration.windowPreferences = [.disableMinimize]
+        configuration.windowPreferences.isMinimizeEnabled = false
 
         let launchArguments = try configuration.encodeLaunchArguments()
 
@@ -92,7 +84,7 @@ class LaunchArgumentEncodableTests: XCTestCase {
         XCTAssertEqual(configuration.lastState, .unregistered)
         XCTAssertNil(configuration.isLegacyUser)
         XCTAssertEqual(configuration.lastVisitDate, Date(timeIntervalSinceReferenceDate: 60 * 60 * 24))
-        XCTAssertEqual(configuration.windowPreferences, [.disableMinimize])
+        XCTAssertEqual(configuration.windowPreferences.isMinimizeEnabled, false)
 
         XCTAssertEqual(launchArguments, [
             "-UUID", "<string>TESTING</string>",
@@ -100,9 +92,7 @@ class LaunchArgumentEncodableTests: XCTestCase {
             "-State", "<string>registered</string>",
             "-LastState", "<string>unregistered</string>",
             "-LastVisitDate", "<date>2001-01-02T00:00:00Z</date>",
-            "-WindowPreferences", "<data>W3siZGlzYWJsZU1pbmltaXplIjp7fX1d</data>",
-            "-AppleLanguages", "<array><string>en</string></array>",
-            "-AppleLocale", "<string>en_US</string>",
+            "-WindowPreferences", "<data>eyJpc0Z1bGxTY3JlZW5TdXBwb3J0ZWQiOmZhbHNlLCJpc01pbmltaXplRW5hYmxlZCI6ZmFsc2V9</data>",
             "UI-Testing"
         ])
     }

--- a/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
+++ b/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
@@ -1,0 +1,109 @@
+import SwiftUserDefaults
+import XCTest
+
+private extension UserDefaults.Key {
+    static let appleLanguages = Self("AppleLanguages")
+    static let appleLocale = Self("AppleLocale")
+}
+
+private extension UserDefaults.Key {
+    static let uuid = Self("UUID")
+    static let user = Self("User")
+    static let state = Self("State")
+    static let lastState = Self("LastState")
+    static let isLegacyUser = Self("LegacyUser")
+    static let lastVisitDate = Self("LastVisitDate")
+    static let windowPreferences = Self("WindowPreferences")
+}
+
+private struct AppConfiguration: LaunchArgumentEncodable {
+    struct User: Codable, Equatable {
+        var name: String
+    }
+
+    enum State: String {
+        case registered, unregistered
+    }
+
+    enum WindowPreference: Codable, Equatable {
+        case fullScreen
+        case fixed(width: Float)
+        case disableMinimize
+    }
+
+    // UserDefaultsStorable with default value
+    @UserDefaultOverride(key: .uuid)
+    var uuid: String = "TESTING"
+
+    // Optional Codable
+    @UserDefaultOverride(key: .user, strategy: .json)
+    var user: User?
+
+    // RawRepresentable with default value
+    @UserDefaultOverride(key: .state)
+    var state: State = .unregistered
+
+    // Optional RawRepresentable
+    @UserDefaultOverride(key: .lastState)
+    var lastState: State?
+
+    // Optional UserDefaultsStorable
+    @UserDefaultOverride(key: .isLegacyUser)
+    var isLegacyUser: Bool?
+
+    // Optional UserDefaultsStorable
+    @UserDefaultOverride(key: .lastVisitDate)
+    var lastVisitDate: Date?
+
+    // Codable with default value
+    @UserDefaultOverride(key: .windowPreferences, strategy: .json)
+    var windowPreferences: [WindowPreference] = []
+
+    // The device locale to mock, can't be represented as a single @UserDefaultOverride
+    var deviceLocale: Locale = Locale(identifier: "en_US")
+
+    // Additonal Launch Arguments
+    var additionalLaunchArguments: [String] {
+        // TODO: Remove this from the tests and place it in the Example project.
+        var container = UserDefaults.ValueContainer()
+        container.set([deviceLocale.languageCode!], forKey: .appleLanguages)
+        container.set(deviceLocale.identifier, forKey: .appleLocale)
+
+        return container.launchArguments + [
+            "UI-Testing"
+        ]
+    }
+}
+
+class LaunchArgumentEncodableTests: XCTestCase {
+    func testEncodeLaunchArguments() throws {
+        var configuration = AppConfiguration()
+        configuration.user = AppConfiguration.User(name: "John")
+        configuration.state = .registered
+        configuration.lastState = .unregistered
+        configuration.lastVisitDate = Date(timeIntervalSinceReferenceDate: 60 * 60 * 24)
+        configuration.windowPreferences = [.disableMinimize]
+
+        let launchArguments = try configuration.encodeLaunchArguments()
+
+        XCTAssertEqual(configuration.uuid, "TESTING")
+        XCTAssertEqual(configuration.user, AppConfiguration.User(name: "John"))
+        XCTAssertEqual(configuration.state, .registered)
+        XCTAssertEqual(configuration.lastState, .unregistered)
+        XCTAssertNil(configuration.isLegacyUser)
+        XCTAssertEqual(configuration.lastVisitDate, Date(timeIntervalSinceReferenceDate: 60 * 60 * 24))
+        XCTAssertEqual(configuration.windowPreferences, [.disableMinimize])
+
+        XCTAssertEqual(launchArguments, [
+            "-UUID", "<string>TESTING</string>",
+            "-User", "<data>eyJuYW1lIjoiSm9obiJ9</data>",
+            "-State", "<string>registered</string>",
+            "-LastState", "<string>unregistered</string>",
+            "-LastVisitDate", "<date>2001-01-02T00:00:00Z</date>",
+            "-WindowPreferences", "<data>W3siZGlzYWJsZU1pbmltaXplIjp7fX1d</data>",
+            "-AppleLanguages", "<array><string>en</string></array>",
+            "-AppleLocale", "<string>en_US</string>",
+            "UI-Testing"
+        ])
+    }
+}

--- a/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
+++ b/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
@@ -96,4 +96,16 @@ class LaunchArgumentEncodableTests: XCTestCase {
             "UI-Testing"
         ])
     }
+
+    func testProjectedValue() throws {
+        // Given a property wrapper
+        @UserDefaultOverride(.state)
+        var state = AppConfiguration.State.registered
+
+        // When the projected value is accessed
+        let projectedValue = $state
+
+        XCTAssertEqual(projectedValue.key, .state)
+        XCTAssertEqual(try projectedValue.getValue() as? String, "registered")
+    }
 }

--- a/Tests/SwiftUserDefaultsTests/UserDefaultsValueContainerTests.swift
+++ b/Tests/SwiftUserDefaultsTests/UserDefaultsValueContainerTests.swift
@@ -63,26 +63,14 @@ final class UserDefaultsValueContainerTests: XCTestCase {
         container.set(true, forKey: .valueTwo)
         container.set(123, forKey: .valueThree)
 
-        // When the launch arguments are chunked by every two item and put into a dictionary (since order is ambiguous)
-        let launchArguments = Dictionary(
-            uniqueKeysWithValues: container.launchArguments
-                .chunked(into: 2)
-                .map({ ($0.first!, $0.last!) })
-        )
+        // When the launch arguments are read
+        let launchArguments = container.launchArguments
 
         // The contents will match as expected
         XCTAssertEqual(launchArguments, [
-            "-ValueOne": "<string>Hello, World</string>",
-            "-ValueTwo": "<true/>",
-            "-ValueThree": "<integer>123</integer>"
+            "-ValueOne", "<string>Hello, World</string>",
+            "-ValueTwo", "<true/>",
+            "-ValueThree", "<integer>123</integer>"
         ])
-    }
-}
-
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
     }
 }


### PR DESCRIPTION
# Background

When prototyping the integration within a real iOS app, I found using `UserDefaults.ValueContainer()` somewhat repetitive. 

We defined a `Configuration` type that held a series of properties that related to UserDefaults, but to map that into the value container resulted in a lot of repetitive code:

<img width="400" alt="Screenshot 2022-01-06 at 23 42 59" src="https://user-images.githubusercontent.com/482871/148462654-337a0997-ebb3-4138-9828-149b16455965.png">
 
It would be great to avoid this somehow.

# Description

In this PR, I'm proposing two new types:

1. The `LaunchArgumentEncodable` protocol
2. The `@UserDefaultOverride` property wrapper

They work in conjunction with each other and build on top of the functionality already provided by `UserDefaults.ValueContainer`. `LaunchArgumentEncodable` is pretty simple:

```swift
/// A protocol used by container types that can have their representations encoded into launch arguments via the ``encodeLaunchArguments()`` method.
///
/// This protocol works exclusively in conjunction with the ``UserDefaultOverride`` property wrapper.
public protocol LaunchArgumentEncodable {
    /// Additional values to be apended to the result of `collectLaunchArguments()`.
    ///
    /// A default implementation is provided that returns an empty array.
    var additionalLaunchArguments: [String] { get }
}

public extension LaunchArgumentEncodable {
    /// Collects the complete array of launch arguments from the reciever.
    ///
    /// The contents of the return value is built by using Reflection to look for all `@UserDefaultOverride` property wrapper instances. See ``UserDefaultOverride`` for more information.
    ///
    /// In addition to overrides, the contents of `additionalLaunchArguments` is apended to the return value.
    func encodeLaunchArguments() throws -> [String]
}
```

But it is somewhat magic. The `encodeLaunchArguments()` method will use Swift's reflection apis to find and iterate all of the `@UserDefaultOverride` properties defined on the type. It'll then collect the keys and values and pass them into a `ValueContainer` that is then used to produce the array of launch arguments. 

In use, it looks something like this:

```swift
class ExampleUITests: XCTestCase {
    struct Configuration: LaunchArgumentEncodable {
        @UserDefaultOverride(.contentTitle)
        var title: String = "Example App (Test)"

        @UserDefaultOverride(.contentItems)
        var items: [Date] = []

        @UserDefaultOverride(.contentSortOrder)
        var sortOrder: ContentSortOrder = .descending

        var deviceLocale: Locale = Locale(identifier: "en_US")

        var additionalLaunchArguments: [String] {
            // Type `Locale` doesn't match how we want to represent the `AppleLocale` UserDefault so we'll encode it manually
            var container = UserDefaults.ValueContainer()
            container.set(deviceLocale.identifier, forKey: UserDefaults.Key("AppleLocale"))

            return container.launchArguments
        }
    }

    func testNoItemsPlaceholder() throws {
        // Override the relevant values
        var configuration = Configuration()
        configuration.deviceLocale = Locale(identifier: "fr_FR")
        configuration.sortOrder = .ascending
        configuration.title = "Example App"

        // Launch the app with the user defaults
        let app = XCUIApplication()
        app.launchArguments = try configuration.encodeLaunchArguments()
        app.launch()

        // ...
    }
}
```

In addition to this change, I updated `UserDefaults.ValueContainer` so that `launchArguments` returns key value pairs ordered based on when they were inserted. This helps us predictably test the output.