### PR TITLE
Drop 'v' prefix from tag names

### DIFF
--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/cookpad/swift-user-defaults"
   s.license = { :type => "MIT", :file => "LICENSE.txt" }
   s.authors = { 'Liam Nichols' => 'liam.nichols.ln@gmail.com', 'Ryan Paterson' => 'ryan-paterson@cookpad.com' }
-  s.source = { :git => "https://github.com/cookpad/swift-user-defaults.git", :tag => "v#{s.version}" }
+  s.source = { :git => "https://github.com/cookpad/swift-user-defaults.git", :tag => "#{s.version}" }
   s.source_files = "Sources/**/*.{swift}"
   s.swift_version = "5.3"
 


### PR DESCRIPTION
# Links

- #7 

Closes #7

# Background 

While it was a bug in the Swift Plagrounds app and its a common standard, using the `v` prefix for tags is unnecessary but I just followed the pattern from some other repos originally 😄 

After having a look at other repos, I now realise that the norm is to just have plain semantic versions for tag names (such as `0.0.3` instead of `v0.0.3`). 

# Description

In this PR, I just drop the `v` prefix from the Podspec, and going forward we can just tag the next release as `0.0.3` rather than `v0.0.3`. 