### PR TITLE
Update `@UserDefaultOverride` optional type initializers to support a default value

### DIFF
--- a/Sources/SwiftUserDefaults/UserDefaultOverride.swift
+++ b/Sources/SwiftUserDefaults/UserDefaultOverride.swift
@@ -142,9 +142,10 @@ public struct UserDefaultOverride<Value>: UserDefaultOverrideRepresentable {
     }
 
     public init<T: UserDefaultsStorable>(
+        wrappedValue defaultValue: Value = nil,
         _ key: UserDefaults.Key
     ) where Value == T? {
-        self.init(wrappedValue: nil, key: key, transform: { $0 })
+        self.init(wrappedValue: defaultValue, key: key, transform: { $0 })
     }
 
     public init(
@@ -155,9 +156,10 @@ public struct UserDefaultOverride<Value>: UserDefaultOverrideRepresentable {
     }
 
     public init<T: RawRepresentable>(
+        wrappedValue defaultValue: Value = nil,
         _ key: UserDefaults.Key
     ) where Value == T?, T.RawValue: UserDefaultsStorable {
-        self.init(wrappedValue: nil, key: key, transform: { $0?.rawValue })
+        self.init(wrappedValue: defaultValue, key: key, transform: { $0?.rawValue })
     }
 
     public init(
@@ -169,9 +171,10 @@ public struct UserDefaultOverride<Value>: UserDefaultOverrideRepresentable {
     }
 
     public init<T: Encodable>(
+        wrappedValue defaultValue: Value = nil,
         _ key: UserDefaults.Key,
         strategy: UserDefaults.CodingStrategy
     ) where Value == T? {
-        self.init(wrappedValue: nil, key: key, transform: { try $0.flatMap({ try strategy.encode($0) }) })
+        self.init(wrappedValue: defaultValue, key: key, transform: { try $0.flatMap({ try strategy.encode($0) }) })
     }
 }

--- a/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
+++ b/Tests/SwiftUserDefaultsTests/LaunchArgumentEncodableTests.swift
@@ -48,7 +48,7 @@ private struct AppConfiguration: LaunchArgumentEncodable {
 
     // Optional UserDefaultsStorable
     @UserDefaultOverride(.isLegacyUser)
-    var isLegacyUser: Bool?
+    var isLegacyUser: Bool? = false
 
     // Optional UserDefaultsStorable
     @UserDefaultOverride(.lastVisitDate)
@@ -82,7 +82,7 @@ class LaunchArgumentEncodableTests: XCTestCase {
         XCTAssertEqual(configuration.user, AppConfiguration.User(name: "John"))
         XCTAssertEqual(configuration.state, .registered)
         XCTAssertEqual(configuration.lastState, .unregistered)
-        XCTAssertNil(configuration.isLegacyUser)
+        XCTAssertEqual(configuration.isLegacyUser, false)
         XCTAssertEqual(configuration.lastVisitDate, Date(timeIntervalSinceReferenceDate: 60 * 60 * 24))
         XCTAssertEqual(configuration.windowPreferences.isMinimizeEnabled, false)
 
@@ -91,6 +91,7 @@ class LaunchArgumentEncodableTests: XCTestCase {
             "-User", "<data>eyJuYW1lIjoiSm9obiJ9</data>",
             "-State", "<string>registered</string>",
             "-LastState", "<string>unregistered</string>",
+            "-LegacyUser", "<false/>",
             "-LastVisitDate", "<date>2001-01-02T00:00:00Z</date>",
             "-WindowPreferences", "<data>eyJpc0Z1bGxTY3JlZW5TdXBwb3J0ZWQiOmZhbHNlLCJpc01pbmltaXplRW5hYmxlZCI6ZmFsc2V9</data>",
             "UI-Testing"


### PR DESCRIPTION
# Background

When implementing the new `@UserDefaultOverride` property wrapper, I ran into the following compile issue:

<img width="791" alt="Screenshot 2022-01-14 at 18 34 48" src="https://user-images.githubusercontent.com/482871/149561079-990dbb8b-2699-4c80-b4f5-9a2ee04d489c.png">

Even if an optional type, we should still be able to provide a non-nil default value.

# Description

This was a mistake on my initial implementation in #8 that I didn't spot. The fix however was simple since I just had to add the `wrappedValue` argument on the initialiser and set its default value to `nil`. 