### PR TITLE
Initial dependabot.yml configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "10:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+    - liamnichols
+  versioning-strategy: lockfile-only
+  insecure-external-code-execution: allow


### PR DESCRIPTION
# Background

It'll be beneficial to run Dependabot on this repo to keep gems up to date.

# Changes

Adding the initial **dependabot.yml** configuration file should be enough to set things up.