### PR TITLE
Add privacy manifest file

### DIFF
--- a/Sources/SwiftUserDefaults/PrivacyInfo.xcprivacy
+++ b/Sources/SwiftUserDefaults/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
# Related links
- https://github.com/cookpad/global-ios/issues/19954

# Why?
Apps and third-party SDKs should contain a privacy manifest file by Spring 2024 to avoid the app review rejection.

# How?
Since swift-user-defaults uses UserDefaults,

- NSPrivacyAccessedAPITypes
  - NSPrivacyAccessedAPIType: `NSPrivacyAccessedAPICategoryUserDefaults`
  - NSPrivacyAccessedAPITypeReasons: `C56D.1`?

# What I'd like you to review/discuss
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401

> C56D.1
Declare this reason if your third-party SDK is providing a wrapper function around user defaults API(s) for the app to use, and you only access the user defaults APIs when the app calls your wrapper function. This reason may only be declared by third-party SDKs. This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).
>
> Information accessed for this reason, or any derived information, may not be used for your third-party SDK’s own purposes or sent off-device by your third-party SDK.

I thought `C56D.1` was appropriate as this library provided wrapper functions around UserDefaults API and added some Swift friendly functionalities.

> This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).

But according to this statement, we can't use it since it's exclusively a UserDefaults API wrapper? 😕
However, if `C56D.1` cannot be used, which one would be appropriate for this library? (I don't think any of the options are suitable for our use...)

## 📝 `flutter/shared_preferences`
`flutter/shared_preferences` is also the wrapper and similar to our use case. They don't declare `C56D.1` but `1C8F.1`instead...
https://github.com/flutter/flutter/issues/139758#issuecomment-1852737278
https://github.com/flutter/packages/pull/5846

--- 
[japanese]
# レビュー/議論したい箇所
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401

> C56D.1
Declare this reason if your third-party SDK is providing a wrapper function around user defaults API(s) for the app to use, and you only access the user defaults APIs when the app calls your wrapper function. This reason may only be declared by third-party SDKs. This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).
>
> Information accessed for this reason, or any derived information, may not be used for your third-party SDK’s own purposes or sent off-device by your third-party SDK.

このライブラリはまさにUserDefaults APIのSwiftで使いやすいラッパー関数を提供しているので、`C56D.1` を宣言するのが適切だと思いました。

> This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).

しかしこの文を読んで、UserDefaults APIをラップすることを主目的としたライブラリだから `C56D.1` を宣言することはできないのか？
でももし `C56D.1` が使えないとなると、このライブラリはどれを宣言するのが適切なのでしょうか？（他のどの選択肢も適切じゃなさそう...）

## 📝 `flutter/shared_preferences`
`flutter/shared_preferences` is also the wrapper and similar to our use case. They don't declare `C56D.1` but `1C8F.1`instead...
https://github.com/flutter/flutter/issues/139758#issuecomment-1852737278
https://github.com/flutter/packages/pull/5846

`flutter/shared_preferences` もUseDefaultsなどのラッパーで私たちの利用に近いライブラリですが、彼らは `C56D.1` ではなく `1C8F.1` を宣言しています...