### PR TITLE
Use sorted keys when encoding using the JSON strategy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "swift-user-defaults",
     platforms: [
-        .macOS(.v10_12),
+        .macOS(.v10_13),
         .iOS(.v11),
         .watchOS(.v7),
-        .tvOS(.v10)
+        .tvOS(.v11)
     ],
     products: [
         .library(name: "SwiftUserDefaults", targets: ["SwiftUserDefaults"]),

--- a/Sources/SwiftUserDefaults/UserDefaults+CodingStrategy.swift
+++ b/Sources/SwiftUserDefaults/UserDefaults+CodingStrategy.swift
@@ -42,7 +42,9 @@ public extension UserDefaults.CodingStrategy {
     func encode<T: Encodable>(_ value: T) throws -> Data {
         switch self {
         case .json:
-            return try JSONEncoder().encode(value)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            return try encoder.encode(value)
         case .plist:
             return try PropertyListEncoder().encode(value)
         }

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.swift_version = "5.3"
 
   s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '11.0'
   s.watchos.deployment_target = '7'
 
   # Run Unit Tests


### PR DESCRIPTION
This change is minor for the end-user where the order of JSON object keys isn't really important, but this causes a failure when running Unit Tests in Xcode 15 due to changes in the iOS 17 SDK:

<img width="1376" alt="Screenshot 2024-01-26 at 12 37 35" src="https://github.com/cookpad/swift-user-defaults/assets/482871/ebfba82f-e411-4800-923e-eb9e22ee0aec">

Therefore we enforce sorted keys moving forward