### PR TITLE
Add PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftUserDefaults", targets: ["SwiftUserDefaults"]),
     ],
     targets: [
-        .target(name: "SwiftUserDefaults", dependencies: []),
+        .target(name: "SwiftUserDefaults", dependencies: [], resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(name: "SwiftUserDefaultsTests", dependencies: ["SwiftUserDefaults"])
     ]
 )

--- a/Sources/SwiftUserDefaults/PrivacyInfo.xcprivacy
+++ b/Sources/SwiftUserDefaults/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "swift-user-defaults"
   s.module_name = "SwiftUserDefaults"
-  s.version = "0.0.4"
+  s.version = "0.0.5"
   s.summary = "A series of Swift friendly utilities for Foundation's UserDefaults class"
   s.homepage = "https://github.com/cookpad/swift-user-defaults"
   s.license = { :type => "MIT", :file => "LICENSE.txt" }

--- a/swift-user-defaults.podspec
+++ b/swift-user-defaults.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.authors = { 'Liam Nichols' => 'liam.nichols.ln@gmail.com', 'Ryan Paterson' => 'ryan-paterson@cookpad.com' }
   s.source = { :git => "https://github.com/cookpad/swift-user-defaults.git", :tag => "#{s.version}" }
   s.source_files = "Sources/**/*.{swift}"
+  s.resource_bundles = {'SwiftUserDefaults' => ['Sources/SwiftUserDefaults/PrivacyInfo.xcprivacy']}
   s.swift_version = "5.3"
 
   s.ios.deployment_target = '11.0'


### PR DESCRIPTION
Add PrivacyInfo.xcprivacy to this library.

`swift-user-defaults` uses the UserDefaults API, so declare

* NSPrivacyAccessedAPITypes
  - NSPrivacyAccessedAPIType: NSPrivacyAccessedAPICategoryUserDefaults
  - NSPrivacyAccessedAPITypeReasons: C56D.1

ref:
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401

---

I will be releasing this change as 0.0.5, so I am bumping the podspec version as well.